### PR TITLE
feat: Add app introduction and postal code setup functionality

### DIFF
--- a/android/app/src/main/java/com/preisvergleich/android/data/preferences/PreferencesRepository.kt
+++ b/android/app/src/main/java/com/preisvergleich/android/data/preferences/PreferencesRepository.kt
@@ -1,0 +1,53 @@
+package com.preisvergleich.android.data.preferences
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_preferences")
+
+@Singleton
+class PreferencesRepository @Inject constructor(
+    private val context: Context
+) {
+    private val dataStore = context.dataStore
+
+    companion object {
+        private val POSTAL_CODE_KEY = stringPreferencesKey("postal_code")
+        private val INTRO_COMPLETED_KEY = booleanPreferencesKey("intro_completed")
+    }
+
+    val postalCode: Flow<String?> = dataStore.data.map { preferences ->
+        preferences[POSTAL_CODE_KEY]
+    }
+
+    val isIntroCompleted: Flow<Boolean> = dataStore.data.map { preferences ->
+        preferences[INTRO_COMPLETED_KEY] ?: false
+    }
+
+    suspend fun savePostalCode(postalCode: String) {
+        dataStore.edit { preferences ->
+            preferences[POSTAL_CODE_KEY] = postalCode
+        }
+    }
+
+    suspend fun setIntroCompleted() {
+        dataStore.edit { preferences ->
+            preferences[INTRO_COMPLETED_KEY] = true
+        }
+    }
+
+    suspend fun clearAllPreferences() {
+        dataStore.edit { preferences ->
+            preferences.clear()
+        }
+    }
+} 

--- a/android/app/src/main/java/com/preisvergleich/android/di/NetworkModule.kt
+++ b/android/app/src/main/java/com/preisvergleich/android/di/NetworkModule.kt
@@ -1,12 +1,15 @@
 package com.preisvergleich.android.di
 
+import android.content.Context
 import com.preisvergleich.android.data.network.ApiService
+import com.preisvergleich.android.data.preferences.PreferencesRepository
 import com.preisvergleich.android.data.repository.SearchRepository
 import com.preisvergleich.android.data.repository.SearchRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -69,6 +72,12 @@ abstract class NetworkModule {
         @Singleton
         fun provideApiService(retrofit: Retrofit): ApiService {
             return retrofit.create(ApiService::class.java)
+        }
+
+        @Provides
+        @Singleton
+        fun providePreferencesRepository(@ApplicationContext context: Context): PreferencesRepository {
+            return PreferencesRepository(context)
         }
     }
 } 

--- a/android/app/src/main/java/com/preisvergleich/android/feature/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/preisvergleich/android/feature/onboarding/OnboardingScreen.kt
@@ -1,0 +1,202 @@
+package com.preisvergleich.android.feature.onboarding
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+
+data class OnboardingPage(
+    val title: String,
+    val description: String,
+    val iconName: String
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OnboardingScreen(
+    onComplete: () -> Unit
+) {
+    val pages = listOf(
+        OnboardingPage(
+            title = "Preise vergleichen",
+            description = "Finden Sie die besten Preise für Ihre Lieblings-Produkte in deutschen Supermärkten.",
+            iconName = "search"
+        ),
+        OnboardingPage(
+            title = "Geld sparen",
+            description = "Sparen Sie bei jedem Einkauf Geld durch intelligente Preisvergleiche.",
+            iconName = "savings"
+        ),
+        OnboardingPage(
+            title = "Einfach & schnell",
+            description = "Suchen Sie einfach nach Produkten und finden Sie sofort die günstigsten Angebote in Ihrer Nähe.",
+            iconName = "fast"
+        )
+    )
+
+    val pagerState = rememberPagerState(pageCount = { pages.size })
+    val scope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(16.dp)
+    ) {
+        // Skip Button
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            TextButton(
+                onClick = onComplete
+            ) {
+                Text(
+                    text = "Überspringen",
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+
+        // Pager
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.weight(1f)
+        ) { page ->
+            OnboardingPageContent(
+                page = pages[page],
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+
+        // Page Indicators
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            repeat(pages.size) { index ->
+                val isSelected = pagerState.currentPage == index
+                Box(
+                    modifier = Modifier
+                        .size(if (isSelected) 12.dp else 8.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (isSelected) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.outline
+                        )
+                        .padding(horizontal = 4.dp)
+                )
+            }
+        }
+
+        // Navigation Buttons
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Back Button
+            if (pagerState.currentPage > 0) {
+                TextButton(
+                    onClick = {
+                        scope.launch {
+                            pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                        }
+                    }
+                ) {
+                    Text("Zurück")
+                }
+            } else {
+                Spacer(modifier = Modifier.width(80.dp))
+            }
+
+            // Next/Finish Button
+            Button(
+                onClick = {
+                    if (pagerState.currentPage < pages.size - 1) {
+                        scope.launch {
+                            pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                        }
+                    } else {
+                        onComplete()
+                    }
+                },
+                modifier = Modifier
+                    .height(48.dp)
+                    .widthIn(min = 120.dp),
+                shape = RoundedCornerShape(24.dp)
+            ) {
+                Text(
+                    text = if (pagerState.currentPage < pages.size - 1) "Weiter" else "Los geht's!",
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun OnboardingPageContent(
+    page: OnboardingPage,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        // Icon Placeholder (in a real app, you'd use actual icons)
+        Box(
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primaryContainer),
+            contentAlignment = Alignment.Center
+        ) {
+            when (page.iconName) {
+                "search" -> Text("🔍", fontSize = 48.sp)
+                "savings" -> Text("💰", fontSize = 48.sp)
+                "fast" -> Text("⚡", fontSize = 48.sp)
+                else -> Text("📱", fontSize = 48.sp)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(48.dp))
+
+        Text(
+            text = page.title,
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = page.description,
+            fontSize = 16.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            lineHeight = 24.sp
+        )
+    }
+} 

--- a/android/app/src/main/java/com/preisvergleich/android/feature/onboarding/PostalCodeSetupScreen.kt
+++ b/android/app/src/main/java/com/preisvergleich/android/feature/onboarding/PostalCodeSetupScreen.kt
@@ -1,0 +1,136 @@
+package com.preisvergleich.android.feature.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostalCodeSetupScreen(
+    onPostalCodeSaved: (String) -> Unit
+) {
+    var postalCode by remember { mutableStateOf("") }
+    var isError by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        // Icon
+        Box(
+            modifier = Modifier
+                .size(100.dp)
+                .background(
+                    MaterialTheme.colorScheme.primaryContainer,
+                    RoundedCornerShape(50.dp)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("📍", fontSize = 48.sp)
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // Title
+        Text(
+            text = "Ihre Postleitzahl",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Description
+        Text(
+            text = "Geben Sie Ihre Postleitzahl ein, um lokale Angebote und Supermärkte in Ihrer Nähe zu finden.",
+            fontSize = 16.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            lineHeight = 24.sp
+        )
+
+        Spacer(modifier = Modifier.height(48.dp))
+
+        // Postal Code Input
+        OutlinedTextField(
+            value = postalCode,
+            onValueChange = { newValue ->
+                // Only allow digits and limit to 5 characters
+                if (newValue.all { it.isDigit() } && newValue.length <= 5) {
+                    postalCode = newValue
+                    isError = false
+                }
+            },
+            label = { Text("Postleitzahl") },
+            placeholder = { Text("z.B. 10115") },
+            isError = isError,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        )
+
+        if (isError) {
+            Text(
+                text = "Bitte geben Sie eine gültige 5-stellige Postleitzahl ein",
+                color = MaterialTheme.colorScheme.error,
+                fontSize = 12.sp,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // Continue Button
+        Button(
+            onClick = {
+                if (postalCode.length == 5) {
+                    onPostalCodeSaved(postalCode)
+                } else {
+                    isError = true
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .padding(horizontal = 16.dp),
+            shape = RoundedCornerShape(28.dp),
+            enabled = postalCode.isNotEmpty()
+        ) {
+            Text(
+                text = "Weiter",
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Skip option
+        TextButton(
+            onClick = { onPostalCodeSaved("") }
+        ) {
+            Text(
+                text = "Später eingeben",
+                color = MaterialTheme.colorScheme.outline
+            )
+        }
+    }
+} 

--- a/android/app/src/main/java/com/preisvergleich/android/feature/search/SearchFilterSheet.kt
+++ b/android/app/src/main/java/com/preisvergleich/android/feature/search/SearchFilterSheet.kt
@@ -21,6 +21,7 @@ fun SearchFilterSheet(
     onSelectedStoresChange: (List<String>) -> Unit,
     onUnitChange: (String?) -> Unit,
     onMaxPriceChange: (BigDecimal?) -> Unit,
+    onPostalCodeChange: (String) -> Unit,
     onClose: () -> Unit
 ) {
     Column(
@@ -53,6 +54,17 @@ fun SearchFilterSheet(
                 )
             }
         }
+        
+        // Postleitzahl
+        OutlinedTextField(
+            value = uiState.postalCode,
+            onValueChange = onPostalCodeChange,
+            label = { Text("Postleitzahl") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth(),
+            supportingText = { Text("Ihre aktuelle Postleitzahl für lokale Angebote") }
+        )
+        
         // Einheit
         OutlinedTextField(
             value = uiState.unit ?: "",

--- a/android/app/src/main/java/com/preisvergleich/android/feature/search/SearchScreen.kt
+++ b/android/app/src/main/java/com/preisvergleich/android/feature/search/SearchScreen.kt
@@ -28,8 +28,16 @@ import java.math.BigDecimal
 @Composable
 fun SearchScreen(
     viewModel: SearchViewModel = hiltViewModel(),
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    initialPostalCode: String? = null,
+    onPostalCodeChanged: (String) -> Unit = {}
 ) {
+    // Initialize postal code when screen is first composed
+    LaunchedEffect(initialPostalCode) {
+        initialPostalCode?.let { 
+            viewModel.onPostalCodeChange(it)
+        }
+    }
     val uiState by viewModel.uiState.collectAsState()
     val focusManager = LocalFocusManager.current
     val filterActive = uiState.selectedStores.isNotEmpty() || uiState.unit != null || uiState.maxPrice != null
@@ -132,14 +140,7 @@ fun SearchScreen(
                     }
                 )
             }
-            // PLZ
-            OutlinedTextField(
-                value = uiState.postalCode,
-                onValueChange = viewModel::onPostalCodeChange,
-                label = { Text("Postleitzahl") },
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
-            )
+
             // Suche-Button
             Button(
                 onClick = { 
@@ -195,6 +196,10 @@ fun SearchScreen(
                     onSelectedStoresChange = viewModel::onSelectedStoresChange,
                     onUnitChange = viewModel::onUnitChange,
                     onMaxPriceChange = viewModel::onMaxPriceChange,
+                    onPostalCodeChange = { newValue ->
+                        viewModel.onPostalCodeChange(newValue)
+                        onPostalCodeChanged(newValue)
+                    },
                     onClose = { viewModel.openFilterSheet(false) }
                 )
             }

--- a/android/app/src/main/java/com/preisvergleich/android/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/preisvergleich/android/ui/AppViewModel.kt
@@ -1,0 +1,81 @@
+package com.preisvergleich.android.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.preisvergleich.android.data.preferences.PreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed class AppDestination {
+    object Onboarding : AppDestination()
+    object PostalCodeSetup : AppDestination()
+    object Main : AppDestination()
+}
+
+data class AppState(
+    val isLoading: Boolean = true,
+    val currentDestination: AppDestination = AppDestination.Onboarding,
+    val postalCode: String? = null
+)
+
+@HiltViewModel
+class AppViewModel @Inject constructor(
+    private val preferencesRepository: PreferencesRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AppState())
+    val state: StateFlow<AppState> = _state.asStateFlow()
+
+    init {
+        observeAppState()
+    }
+
+    private fun observeAppState() {
+        viewModelScope.launch {
+            combine(
+                preferencesRepository.isIntroCompleted,
+                preferencesRepository.postalCode
+            ) { isIntroCompleted, postalCode ->
+                when {
+                    !isIntroCompleted -> AppDestination.Onboarding
+                    postalCode.isNullOrBlank() -> AppDestination.PostalCodeSetup
+                    else -> AppDestination.Main
+                }
+            }.collect { destination ->
+                _state.value = _state.value.copy(
+                    isLoading = false,
+                    currentDestination = destination,
+                    postalCode = preferencesRepository.postalCode.first()
+                )
+            }
+        }
+    }
+
+    fun completeOnboarding() {
+        viewModelScope.launch {
+            preferencesRepository.setIntroCompleted()
+        }
+    }
+
+    fun savePostalCode(postalCode: String) {
+        viewModelScope.launch {
+            if (postalCode.isNotBlank()) {
+                preferencesRepository.savePostalCode(postalCode)
+            }
+            // Navigate to main even if postal code is empty (user can set it later)
+            _state.value = _state.value.copy(
+                currentDestination = AppDestination.Main,
+                postalCode = postalCode.ifBlank { null }
+            )
+        }
+    }
+
+    fun updatePostalCode(postalCode: String) {
+        viewModelScope.launch {
+            preferencesRepository.savePostalCode(postalCode)
+            _state.value = _state.value.copy(postalCode = postalCode)
+        }
+    }
+} 

--- a/android/app/src/main/java/com/preisvergleich/android/ui/PreisvergleichApp.kt
+++ b/android/app/src/main/java/com/preisvergleich/android/ui/PreisvergleichApp.kt
@@ -1,29 +1,59 @@
 package com.preisvergleich.android.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.preisvergleich.android.feature.onboarding.OnboardingScreen
+import com.preisvergleich.android.feature.onboarding.PostalCodeSetupScreen
 import com.preisvergleich.android.feature.search.SearchScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PreisvergleichApp() {
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("Preisvergleich") }
+fun PreisvergleichApp(
+    viewModel: AppViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsState()
+
+    when {
+        state.isLoading -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        state.currentDestination is AppDestination.Onboarding -> {
+            OnboardingScreen(
+                onComplete = viewModel::completeOnboarding
             )
         }
-    ) { paddingValues ->
-        SearchScreen(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-        )
+        state.currentDestination is AppDestination.PostalCodeSetup -> {
+            PostalCodeSetupScreen(
+                onPostalCodeSaved = viewModel::savePostalCode
+            )
+        }
+        state.currentDestination is AppDestination.Main -> {
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        title = { Text("Preisvergleich") }
+                    )
+                }
+            ) { paddingValues ->
+                SearchScreen(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                    initialPostalCode = state.postalCode,
+                    onPostalCodeChanged = viewModel::updatePostalCode
+                )
+            }
+        }
     }
 } 

--- a/ios/PreisvergleichApp/Services/UserDefaultsManager.swift
+++ b/ios/PreisvergleichApp/Services/UserDefaultsManager.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Combine
+
+class UserDefaultsManager: ObservableObject {
+    static let shared = UserDefaultsManager()
+    
+    // Keys for UserDefaults
+    private enum Keys {
+        static let isOnboardingCompleted = "isOnboardingCompleted"
+        static let postalCode = "postalCode"
+    }
+    
+    // Published properties
+    @Published var isOnboardingCompleted: Bool {
+        didSet {
+            UserDefaults.standard.set(isOnboardingCompleted, forKey: Keys.isOnboardingCompleted)
+        }
+    }
+    
+    @Published var postalCode: String {
+        didSet {
+            UserDefaults.standard.set(postalCode, forKey: Keys.postalCode)
+        }
+    }
+    
+    private init() {
+        self.isOnboardingCompleted = UserDefaults.standard.bool(forKey: Keys.isOnboardingCompleted)
+        self.postalCode = UserDefaults.standard.string(forKey: Keys.postalCode) ?? ""
+    }
+    
+    // Methods
+    func completeOnboarding() {
+        isOnboardingCompleted = true
+    }
+    
+    func savePostalCode(_ code: String) {
+        postalCode = code
+    }
+    
+    func clearAll() {
+        UserDefaults.standard.removeObject(forKey: Keys.isOnboardingCompleted)
+        UserDefaults.standard.removeObject(forKey: Keys.postalCode)
+        isOnboardingCompleted = false
+        postalCode = ""
+    }
+} 

--- a/ios/PreisvergleichApp/Views/OnboardingView.swift
+++ b/ios/PreisvergleichApp/Views/OnboardingView.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+struct OnboardingPage {
+    let title: String
+    let description: String
+    let systemImage: String
+    let backgroundColor: Color
+}
+
+struct OnboardingView: View {
+    @Binding var isCompleted: Bool
+    @State private var currentPage = 0
+    
+    private let pages = [
+        OnboardingPage(
+            title: "Preise vergleichen",
+            description: "Finden Sie die besten Preise für Ihre Lieblings-Produkte in deutschen Supermärkten.",
+            systemImage: "magnifyingglass",
+            backgroundColor: .blue
+        ),
+        OnboardingPage(
+            title: "Geld sparen",
+            description: "Sparen Sie bei jedem Einkauf Geld durch intelligente Preisvergleiche.",
+            systemImage: "banknote",
+            backgroundColor: .green
+        ),
+        OnboardingPage(
+            title: "Einfach & schnell",
+            description: "Suchen Sie einfach nach Produkten und finden Sie sofort die günstigsten Angebote in Ihrer Nähe.",
+            systemImage: "bolt.fill",
+            backgroundColor: .orange
+        )
+    ]
+    
+    var body: some View {
+        VStack {
+            HStack {
+                Spacer()
+                Button("Überspringen") {
+                    isCompleted = true
+                }
+                .foregroundColor(.primary)
+                .padding()
+            }
+            
+            TabView(selection: $currentPage) {
+                ForEach(0..<pages.count, id: \.self) { index in
+                    OnboardingPageView(page: pages[index])
+                        .tag(index)
+                }
+            }
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
+            
+            // Custom Page Indicator
+            HStack(spacing: 8) {
+                ForEach(0..<pages.count, id: \.self) { index in
+                    Circle()
+                        .fill(currentPage == index ? Color.primary : Color.gray.opacity(0.4))
+                        .frame(width: currentPage == index ? 12 : 8, height: currentPage == index ? 12 : 8)
+                        .animation(.easeInOut(duration: 0.3), value: currentPage)
+                }
+            }
+            .padding(.vertical)
+            
+            // Navigation Buttons
+            HStack {
+                if currentPage > 0 {
+                    Button("Zurück") {
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            currentPage -= 1
+                        }
+                    }
+                    .foregroundColor(.primary)
+                } else {
+                    Spacer()
+                }
+                
+                Spacer()
+                
+                Button(action: {
+                    if currentPage < pages.count - 1 {
+                        withAnimation(.easeInOut(duration: 0.3)) {
+                            currentPage += 1
+                        }
+                    } else {
+                        isCompleted = true
+                    }
+                }) {
+                    Text(currentPage < pages.count - 1 ? "Weiter" : "Los geht's!")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 30)
+                        .padding(.vertical, 12)
+                        .background(
+                            LinearGradient(
+                                gradient: Gradient(colors: [.blue, .purple]),
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .cornerRadius(25)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 30)
+        }
+        .background(Color(.systemBackground))
+    }
+}
+
+struct OnboardingPageView: View {
+    let page: OnboardingPage
+    
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+            
+            // Icon
+            ZStack {
+                Circle()
+                    .fill(page.backgroundColor.opacity(0.2))
+                    .frame(width: 120, height: 120)
+                
+                Image(systemName: page.systemImage)
+                    .font(.system(size: 50))
+                    .foregroundColor(page.backgroundColor)
+            }
+            
+            VStack(spacing: 16) {
+                Text(page.title)
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.primary)
+                
+                Text(page.description)
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 32)
+                    .lineLimit(nil)
+            }
+            
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    OnboardingView(isCompleted: .constant(false))
+} 

--- a/ios/PreisvergleichApp/Views/PostalCodeSetupView.swift
+++ b/ios/PreisvergleichApp/Views/PostalCodeSetupView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+struct PostalCodeSetupView: View {
+    @State private var postalCode = ""
+    @State private var isError = false
+    @FocusState private var isTextFieldFocused: Bool
+    
+    let onComplete: (String) -> Void
+    
+    var body: some View {
+        VStack(spacing: 30) {
+            Spacer()
+            
+            // Icon
+            ZStack {
+                Circle()
+                    .fill(Color.blue.opacity(0.2))
+                    .frame(width: 100, height: 100)
+                
+                Image(systemName: "location.circle.fill")
+                    .font(.system(size: 50))
+                    .foregroundColor(.blue)
+            }
+            
+            VStack(spacing: 16) {
+                Text("Ihre Postleitzahl")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.primary)
+                
+                Text("Geben Sie Ihre Postleitzahl ein, um lokale Angebote und Supermärkte in Ihrer Nähe zu finden.")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 32)
+                    .lineLimit(nil)
+            }
+            
+            VStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    TextField("z.B. 10115", text: $postalCode)
+                        .keyboardType(.numberPad)
+                        .focused($isTextFieldFocused)
+                        .onChange(of: postalCode) { _, newValue in
+                            // Only allow digits and limit to 5 characters
+                            let filtered = newValue.filter { $0.isNumber }
+                            if filtered.count <= 5 {
+                                postalCode = filtered
+                                isError = false
+                            } else {
+                                postalCode = String(filtered.prefix(5))
+                            }
+                        }
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(isError ? Color.red : Color.clear, lineWidth: 1)
+                        )
+                    
+                    if isError {
+                        Text("Bitte geben Sie eine gültige 5-stellige Postleitzahl ein")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding(.horizontal, 24)
+                
+                Button(action: {
+                    if postalCode.count == 5 {
+                        onComplete(postalCode)
+                    } else {
+                        isError = true
+                    }
+                }) {
+                    Text("Weiter")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(
+                            LinearGradient(
+                                gradient: Gradient(colors: [.blue, .purple]),
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                        )
+                        .cornerRadius(12)
+                        .opacity(postalCode.isEmpty ? 0.6 : 1.0)
+                }
+                .disabled(postalCode.isEmpty)
+                .padding(.horizontal, 24)
+                
+                Button("Später eingeben") {
+                    onComplete("")
+                }
+                .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+        }
+        .background(Color(.systemBackground))
+        .onAppear {
+            isTextFieldFocused = true
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Fertig") {
+                    isTextFieldFocused = false
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PostalCodeSetupView { postalCode in
+        print("Postal code: \(postalCode)")
+    }
+} 


### PR DESCRIPTION
- Implement 3-page onboarding flow with progress indicators
- Add postal code setup with validation
- Move postal code from main search to filter sheets only
- Store preferences locally (DataStore for Android, UserDefaults for iOS)
- Add navigation state management for onboarding flow
- Fix button callback issue in iOS onboarding using closure pattern
- Both Android and iOS builds tested and working

Android implementation:
- PreferencesRepository with DataStore
- OnboardingScreen with swipe navigation
- PostalCodeSetupScreen with input validation
- AppViewModel for navigation state
- Updated DI modules
- Modified SearchScreen and SearchFilterSheet

iOS implementation:
- OnboardingView with TabView navigation
- PostalCodeSetupView with validation
- UserDefaultsManager for settings storage
- Updated ContentView with proper state management
- Fixed binding issues using callback pattern